### PR TITLE
Add responsive equipment status form

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Equipment Status Form</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header class="site-header">
+        <img src="logo.svg" alt="Logo" class="logo">
+        <div class="header-buttons">
+            <button class="header-btn">Support</button>
+            <button class="header-btn">Logout</button>
+        </div>
+    </header>
+    
+    <main>
+        <section class="form-container" id="form-container">
+            <form id="equipment-form">
+                <div class="form-group">
+                    <label for="operator">Operator</label>
+                    <div class="input-icon">
+                        <span class="icon">👤</span>
+                        <input type="text" id="operator" name="operator" required>
+                    </div>
+                    <small class="error" id="operator-error"></small>
+                </div>
+
+                <div class="form-group">
+                    <label for="equipment">Equipment</label>
+                    <div class="input-icon">
+                        <span class="icon">⚙️</span>
+                        <select id="equipment" name="equipment" required>
+                            <option value="">Select Equipment</option>
+                            <option value="Forklift">Forklift</option>
+                            <option value="Conveyor">Conveyor</option>
+                            <option value="Loader">Loader</option>
+                        </select>
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <label for="status">Status</label>
+                    <select id="status" name="status" required>
+                        <option value="">Select Status</option>
+                        <option value="Passed">Passed</option>
+                        <option value="Failed">Failed</option>
+                    </select>
+                </div>
+
+                <div class="form-group">
+                    <label>Daily Status</label>
+                    <div class="days-wrapper">
+                        <div class="day" data-day="monday">
+                            <span class="day-label">Mon</span>
+                            <div class="options">
+                                <button type="button" class="pill online" data-value="Online">✅</button>
+                                <button type="button" class="pill offline" data-value="Offline">❌</button>
+                                <button type="button" class="pill standby" data-value="Standby">⏸️</button>
+                            </div>
+                            <input type="hidden" name="monday_status" value="">
+                        </div>
+                        <div class="day" data-day="tuesday">
+                            <span class="day-label">Tue</span>
+                            <div class="options">
+                                <button type="button" class="pill online" data-value="Online">✅</button>
+                                <button type="button" class="pill offline" data-value="Offline">❌</button>
+                                <button type="button" class="pill standby" data-value="Standby">⏸️</button>
+                            </div>
+                            <input type="hidden" name="tuesday_status" value="">
+                        </div>
+                        <div class="day" data-day="wednesday">
+                            <span class="day-label">Wed</span>
+                            <div class="options">
+                                <button type="button" class="pill online" data-value="Online">✅</button>
+                                <button type="button" class="pill offline" data-value="Offline">❌</button>
+                                <button type="button" class="pill standby" data-value="Standby">⏸️</button>
+                            </div>
+                            <input type="hidden" name="wednesday_status" value="">
+                        </div>
+                        <div class="day" data-day="thursday">
+                            <span class="day-label">Thu</span>
+                            <div class="options">
+                                <button type="button" class="pill online" data-value="Online">✅</button>
+                                <button type="button" class="pill offline" data-value="Offline">❌</button>
+                                <button type="button" class="pill standby" data-value="Standby">⏸️</button>
+                            </div>
+                            <input type="hidden" name="thursday_status" value="">
+                        </div>
+                        <div class="day" data-day="friday">
+                            <span class="day-label">Fri</span>
+                            <div class="options">
+                                <button type="button" class="pill online" data-value="Online">✅</button>
+                                <button type="button" class="pill offline" data-value="Offline">❌</button>
+                                <button type="button" class="pill standby" data-value="Standby">⏸️</button>
+                            </div>
+                            <input type="hidden" name="friday_status" value="">
+                        </div>
+                        <div class="day" data-day="saturday">
+                            <span class="day-label">Sat</span>
+                            <div class="options">
+                                <button type="button" class="pill online" data-value="Online">✅</button>
+                                <button type="button" class="pill offline" data-value="Offline">❌</button>
+                                <button type="button" class="pill standby" data-value="Standby">⏸️</button>
+                            </div>
+                            <input type="hidden" name="saturday_status" value="">
+                        </div>
+                        <div class="day" data-day="sunday">
+                            <span class="day-label">Sun</span>
+                            <div class="options">
+                                <button type="button" class="pill online" data-value="Online">✅</button>
+                                <button type="button" class="pill offline" data-value="Offline">❌</button>
+                                <button type="button" class="pill standby" data-value="Standby">⏸️</button>
+                            </div>
+                            <input type="hidden" name="sunday_status" value="">
+                        </div>
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <label class="switch">
+                        <input type="checkbox" id="downtime" name="downtime">
+                        <span class="slider"></span>
+                        <span class="switch-label">Downtime</span>
+                    </label>
+                </div>
+
+                <div id="downtime-fields" class="hidden">
+                    <div class="form-group">
+                        <label for="planned_downtime">Planned Downtime</label>
+                        <input type="time" id="planned_downtime" name="planned_downtime">
+                    </div>
+                    <div class="form-group">
+                        <label for="unplanned_downtime">Unplanned Downtime</label>
+                        <input type="time" id="unplanned_downtime" name="unplanned_downtime">
+                    </div>
+                </div>
+
+                <button type="submit" class="submit-btn">Submit</button>
+            </form>
+        </section>
+        <div id="toast" class="toast"></div>
+    </main>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/logo.svg
+++ b/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
+  <rect width="40" height="40" fill="#555"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="14" fill="#fff">Logo</text>
+</svg>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,73 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const form = document.getElementById('equipment-form');
+    const downtimeCheckbox = document.getElementById('downtime');
+    const downtimeFields = document.getElementById('downtime-fields');
+    const operatorInput = document.getElementById('operator');
+    const operatorError = document.getElementById('operator-error');
+    const toast = document.getElementById('toast');
+
+    // Daily status toggles
+    document.querySelectorAll('.day').forEach(day => {
+        const hidden = day.querySelector('input[type="hidden"]');
+        day.querySelectorAll('.pill').forEach(btn => {
+            btn.addEventListener('click', () => {
+                day.querySelectorAll('.pill').forEach(b => b.classList.remove('active'));
+                btn.classList.add('active');
+                hidden.value = btn.dataset.value;
+            });
+        });
+    });
+
+    // Downtime toggle logic
+    downtimeCheckbox.addEventListener('change', () => {
+        if (downtimeCheckbox.checked) {
+            downtimeFields.classList.remove('hidden');
+        } else {
+            downtimeFields.classList.add('hidden');
+            downtimeFields.querySelectorAll('input').forEach(i => i.value = '');
+        }
+    });
+
+    // Real-time validation for operator
+    operatorInput.addEventListener('input', () => {
+        if (operatorInput.value.trim() === '') {
+            operatorError.textContent = 'Operator is required';
+        } else {
+            operatorError.textContent = '';
+        }
+    });
+
+    // Form submission
+    form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        if (operatorInput.value.trim() === '') {
+            operatorError.textContent = 'Operator is required';
+            operatorInput.focus();
+            return;
+        }
+
+        const formData = new FormData(form);
+        try {
+            const response = await fetch('submit.php', {
+                method: 'POST',
+                body: formData
+            });
+            const data = await response.json();
+            showToast(data.message);
+            if (data.success) {
+                form.reset();
+                document.querySelectorAll('.pill').forEach(p => p.classList.remove('active'));
+                downtimeFields.classList.add('hidden');
+                window.scrollTo({ top: 0, behavior: 'smooth' });
+            }
+        } catch (err) {
+            showToast('Submission failed');
+        }
+    });
+
+    function showToast(msg) {
+        toast.textContent = msg;
+        toast.classList.add('show');
+        setTimeout(() => toast.classList.remove('show'), 3000);
+    }
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,251 @@
+/* Global Styles */
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: Arial, sans-serif;
+    background: linear-gradient(135deg, #016EC8, #1A1D20);
+    min-height: 100vh;
+    color: #fff;
+    animation: bgFade 1s ease-out;
+}
+
+@keyframes bgFade {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+/* Header */
+.site-header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    background: #20252a;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.5rem 1rem;
+    z-index: 10;
+    animation: slideDown 0.5s ease-out;
+}
+
+@keyframes slideDown {
+    from { transform: translateY(-100%); }
+    to { transform: translateY(0); }
+}
+
+.logo {
+    height: 40px;
+}
+
+.header-buttons {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.header-btn {
+    background: transparent;
+    color: #fff;
+    border: 1px solid #fff;
+    padding: 0.3rem 0.6rem;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background 0.3s, transform 0.2s;
+}
+
+.header-btn:hover {
+    background: rgba(255, 255, 255, 0.2);
+    transform: scale(1.05);
+}
+
+@media (max-width: 480px) {
+    .header-buttons {
+        flex-direction: column;
+        align-items: flex-end;
+    }
+}
+
+/* Form Container */
+main {
+    padding-top: 80px; /* space for fixed header */
+}
+
+.form-container {
+    max-width: 600px;
+    margin: 1rem auto;
+    padding: 1.5rem;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 1rem;
+    backdrop-filter: blur(10px);
+    box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
+    animation: fadeInUp 0.6s ease-out;
+}
+
+@keyframes fadeInUp {
+    from { opacity: 0; transform: translateY(20px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.form-group {
+    margin-bottom: 1rem;
+}
+
+label {
+    display: block;
+    margin-bottom: 0.3rem;
+}
+
+.input-icon {
+    position: relative;
+}
+
+.input-icon .icon {
+    position: absolute;
+    left: 0.5rem;
+    top: 50%;
+    transform: translateY(-50%);
+}
+
+.input-icon input,
+.input-icon select {
+    width: 100%;
+    padding: 0.5rem 0.5rem 0.5rem 2rem;
+    border-radius: 0.5rem;
+    border: none;
+}
+
+select {
+    padding-left: 2rem;
+}
+
+.error {
+    color: #ff9393;
+    font-size: 0.8rem;
+    margin-top: 0.3rem;
+}
+
+/* Daily Status */
+.days-wrapper {
+    display: flex;
+    overflow-x: auto;
+    gap: 0.5rem;
+    padding-bottom: 0.5rem;
+}
+
+.day {
+    min-width: 80px;
+    text-align: center;
+}
+
+.day-label {
+    display: block;
+    margin-bottom: 0.3rem;
+}
+
+.options {
+    display: flex;
+    gap: 0.3rem;
+    justify-content: center;
+}
+
+.pill {
+    border: none;
+    border-radius: 9999px;
+    padding: 0.3rem;
+    cursor: pointer;
+    transition: transform 0.2s;
+    font-size: 1rem;
+}
+
+.pill.online.active { background: #16a34a; }
+.pill.offline.active { background: #dc2626; }
+.pill.standby.active { background: #d97706; }
+
+.pill:hover {
+    transform: scale(1.1);
+}
+
+/* Downtime Switch */
+.switch {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.switch input { display: none; }
+
+.slider {
+    width: 40px;
+    height: 20px;
+    background: #555;
+    border-radius: 10px;
+    position: relative;
+    transition: background 0.3s;
+}
+
+.slider:before {
+    content: "";
+    position: absolute;
+    width: 16px;
+    height: 16px;
+    background: #fff;
+    border-radius: 50%;
+    top: 2px;
+    left: 2px;
+    transition: transform 0.3s;
+}
+
+.switch input:checked + .slider {
+    background: #16a34a;
+}
+
+.switch input:checked + .slider:before {
+    transform: translateX(20px);
+}
+
+.hidden {
+    display: none;
+}
+
+/* Submit Button */
+.submit-btn {
+    width: 100%;
+    padding: 0.8rem;
+    border: none;
+    border-radius: 0.5rem;
+    background: linear-gradient(90deg, #2563eb, #1e3a8a);
+    color: #fff;
+    font-size: 1.1rem;
+    cursor: pointer;
+    transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.submit-btn:hover {
+    transform: scale(1.02);
+    box-shadow: 0 4px 10px rgba(0,0,0,0.2);
+}
+
+/* Toast */
+.toast {
+    position: fixed;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(0,0,0,0.7);
+    color: #fff;
+    padding: 0.8rem 1.2rem;
+    border-radius: 0.5rem;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s;
+    z-index: 20;
+}
+
+.toast.show {
+    opacity: 1;
+}

--- a/submit.php
+++ b/submit.php
@@ -1,0 +1,42 @@
+<?php
+header('Content-Type: application/json');
+
+$required = ['operator','equipment','status','monday_status','tuesday_status','wednesday_status','thursday_status','friday_status','saturday_status','sunday_status'];
+
+foreach ($required as $field) {
+    if (empty($_POST[$field])) {
+        echo json_encode(['success'=>false,'message'=>"Missing field: $field"]);
+        exit;
+    }
+}
+
+$downtime = isset($_POST['downtime']) ? 1 : 0;
+$planned = !empty($_POST['planned_downtime']) ? $_POST['planned_downtime'] : null;
+$unplanned = !empty($_POST['unplanned_downtime']) ? $_POST['unplanned_downtime'] : null;
+
+try {
+    $pdo = new PDO('mysql:host=localhost;dbname=YOUR_DB;charset=utf8mb4','USERNAME','PASSWORD');
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+    $stmt = $pdo->prepare('INSERT INTO equipment_status_form (operator,equipment,status,monday_status,tuesday_status,wednesday_status,thursday_status,friday_status,saturday_status,sunday_status,downtime,planned_downtime,unplanned_downtime,created_at) VALUES (:operator,:equipment,:status,:monday,:tuesday,:wednesday,:thursday,:friday,:saturday,:sunday,:downtime,:planned,:unplanned,NOW())');
+
+    $stmt->execute([
+        ':operator' => $_POST['operator'],
+        ':equipment' => $_POST['equipment'],
+        ':status' => $_POST['status'],
+        ':monday' => $_POST['monday_status'],
+        ':tuesday' => $_POST['tuesday_status'],
+        ':wednesday' => $_POST['wednesday_status'],
+        ':thursday' => $_POST['thursday_status'],
+        ':friday' => $_POST['friday_status'],
+        ':saturday' => $_POST['saturday_status'],
+        ':sunday' => $_POST['sunday_status'],
+        ':downtime' => $downtime,
+        ':planned' => $planned,
+        ':unplanned' => $unplanned
+    ]);
+
+    echo json_encode(['success'=>true,'message'=>'Form submitted successfully']);
+} catch (PDOException $e) {
+    echo json_encode(['success'=>false,'message'=>'Database error']);
+}


### PR DESCRIPTION
## Summary
- Build mobile-first equipment status form with glassmorphism panels
- Add interactive daily status toggles, downtime switch, and toast notifications
- Implement PHP backend using PDO to save form data securely

## Testing
- `php -l submit.php`


------
https://chatgpt.com/codex/tasks/task_e_6894882dd58883318d47e754267d1579