### PR TITLE
Add location and current status fields

### DIFF
--- a/get_geofences.php
+++ b/get_geofences.php
@@ -1,0 +1,25 @@
+<?php
+header('Content-Type: application/json');
+
+$host = 'localhost';
+$db   = 'database';
+$user = 'username';
+$pass = 'password';
+$charset = 'utf8mb4';
+
+$dsn = "mysql:host=$host;dbname=$db;charset=$charset";
+$options = [
+    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_EMULATE_PREPARES   => false,
+];
+
+try {
+    $pdo = new PDO($dsn, $user, $pass, $options);
+    $stmt = $pdo->query('SELECT name FROM geofences');
+    $names = $stmt->fetchAll(PDO::FETCH_COLUMN);
+    echo json_encode($names);
+} catch (PDOException $e) {
+    echo json_encode([]);
+}
+?>

--- a/index.html
+++ b/index.html
@@ -43,13 +43,32 @@
                 </select>
             </section>
 
-            <!-- Status Panel -->
+            <!-- Inspection Panel -->
             <section class="panel">
-                <h2><i class="fa-solid fa-clipboard-check"></i> Status</h2>
+                <h2><i class="fa-solid fa-clipboard-check"></i> Inspection</h2>
                 <select name="status" id="status" required>
-                    <option value="" disabled selected>Select status</option>
+                    <option value="" disabled selected>Select inspection</option>
                     <option value="Passed">Passed</option>
                     <option value="Failed">Failed</option>
+                </select>
+            </section>
+
+            <!-- Location Panel -->
+            <section class="panel">
+                <h2><i class="fa-solid fa-location-dot"></i> Location</h2>
+                <select name="location" id="location" required>
+                    <option value="" disabled selected>Select location</option>
+                </select>
+            </section>
+
+            <!-- Current Status Panel -->
+            <section class="panel">
+                <h2><i class="fa-solid fa-car-side"></i> Current Status</h2>
+                <select name="current_status" id="current_status" required>
+                    <option value="" disabled selected>Select current status</option>
+                    <option value="Driving">Driving</option>
+                    <option value="Parked">Parked</option>
+                    <option value="Inactive">Inactive</option>
                 </select>
             </section>
 

--- a/script.js
+++ b/script.js
@@ -1,3 +1,19 @@
+// Populate locations from server
+const locationSelect = document.getElementById('location');
+if (locationSelect) {
+    fetch('get_geofences.php')
+        .then(res => res.json())
+        .then(data => {
+            data.forEach(name => {
+                const opt = document.createElement('option');
+                opt.value = name;
+                opt.textContent = name;
+                locationSelect.appendChild(opt);
+            });
+        })
+        .catch(() => console.error('Failed to load locations'));
+}
+
 // Daily status toggles
 const daySections = document.querySelectorAll('.day');
 daySections.forEach(day => {
@@ -47,12 +63,19 @@ form.addEventListener('submit', async (e) => {
     feedback.className = 'form-feedback';
     submitBtn.classList.add('loading');
 
-    const requiredFields = ['operator', 'equipment', 'status'];
+    const fieldLabels = {
+        operator: 'operator',
+        equipment: 'equipment',
+        status: 'inspection',
+        location: 'location',
+        current_status: 'current status'
+    };
+    const requiredFields = Object.keys(fieldLabels);
     for (let field of requiredFields) {
         const el = document.getElementById(field);
         if (!el.value) {
             el.classList.add('error');
-            feedback.textContent = `Please select a ${field}.`;
+            feedback.textContent = `Please select a ${fieldLabels[field]}.`;
             feedback.classList.add('error');
             submitBtn.classList.remove('loading');
             return;

--- a/submit.php
+++ b/submit.php
@@ -22,6 +22,8 @@ try {
 }
 
 $operator = trim($_POST['operator'] ?? '');
+$currentStatus = trim($_POST['current_status'] ?? '');
+$location = trim($_POST['location'] ?? '');
 $equipment = trim($_POST['equipment'] ?? '');
 $status = trim($_POST['status'] ?? '');
 
@@ -37,8 +39,8 @@ $plannedEnd = $_POST['planned_downtime_end'] ?? null;
 $unplannedStart = $_POST['unplanned_downtime_start'] ?? null;
 $unplannedEnd = $_POST['unplanned_downtime_end'] ?? null;
 
-if ($operator === '' || $equipment === '' || $status === '') {
-    echo json_encode(['success' => false, 'message' => 'Operator, equipment and status are required.']);
+if ($operator === '' || $currentStatus === '' || $location === '' || $equipment === '' || $status === '') {
+    echo json_encode(['success' => false, 'message' => 'Operator, current status, location, equipment and inspection are required.']);
     exit;
 }
 
@@ -50,12 +52,12 @@ if ($downtime) {
 }
 
 $sql = "INSERT INTO equipment_status_form (
-            operator, equipment, status,
+            operator, current_status, location, equipment, status,
             monday_status, tuesday_status, wednesday_status, thursday_status, friday_status, saturday_status, sunday_status,
             downtime, planned_downtime_start, planned_downtime_end, unplanned_downtime_start, unplanned_downtime_end,
             created_at
         ) VALUES (
-            :operator, :equipment, :status,
+            :operator, :current_status, :location, :equipment, :status,
             :monday, :tuesday, :wednesday, :thursday, :friday, :saturday, :sunday,
             :downtime, :planned_start, :planned_end, :unplanned_start, :unplanned_end,
             NOW()
@@ -65,6 +67,8 @@ try {
     $stmt = $pdo->prepare($sql);
     $stmt->execute([
         ':operator' => $operator,
+        ':current_status' => $currentStatus,
+        ':location' => $location,
         ':equipment' => $equipment,
         ':status' => $status,
         ':monday' => $dayStatuses['monday'],


### PR DESCRIPTION
## Summary
- Rename Status panel to Inspection
- Add Location dropdown fed from geofences table
- Introduce Current Status selector with preset options
- Store new fields on submission and expose endpoint for geofence names

## Testing
- `php -l submit.php get_geofences.php`
- `node --check script.js`
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68a4704561ec8331b55864633e2072c4