### PR TITLE
Generate random coordinate for form submissions

### DIFF
--- a/submit.php
+++ b/submit.php
@@ -21,6 +21,42 @@ try {
     exit;
 }
 
+// Ray casting algorithm for checking if point is inside polygon
+function pointInPolygon(array $point, array $polygon): bool {
+    $y = $point[0]; // latitude
+    $x = $point[1]; // longitude
+    $inside = false;
+    $n = count($polygon);
+    for ($i = 0, $j = $n - 1; $i < $n; $j = $i++) {
+        $yi = $polygon[$i][0];
+        $xi = $polygon[$i][1];
+        $yj = $polygon[$j][0];
+        $xj = $polygon[$j][1];
+        $intersect = (($yi > $y) != ($yj > $y)) &&
+                     ($x < ($xj - $xi) * ($y - $yi) / ($yj - $yi) + $xi);
+        if ($intersect) {
+            $inside = !$inside;
+        }
+    }
+    return $inside;
+}
+
+function randomPointInPolygon(array $polygon): array {
+    $lats = array_column($polygon, 0);
+    $lngs = array_column($polygon, 1);
+    $minLat = min($lats);
+    $maxLat = max($lats);
+    $minLng = min($lngs);
+    $maxLng = max($lngs);
+
+    do {
+        $lat = $minLat + lcg_value() * ($maxLat - $minLat);
+        $lng = $minLng + lcg_value() * ($maxLng - $minLng);
+    } while (!pointInPolygon([$lat, $lng], $polygon));
+
+    return [$lat, $lng];
+}
+
 $operator = trim($_POST['operator'] ?? '');
 $currentStatus = trim($_POST['current_status'] ?? '');
 $location = trim($_POST['location'] ?? '');
@@ -51,15 +87,34 @@ if ($downtime) {
     }
 }
 
+// Fetch polygon for selected location and generate random coordinate
+$geoStmt = $pdo->prepare('SELECT coordinates FROM geofences WHERE name = :name LIMIT 1');
+$geoStmt->execute([':name' => $location]);
+$geoRow = $geoStmt->fetch();
+if (!$geoRow) {
+    echo json_encode(['success' => false, 'message' => 'Selected location not found.']);
+    exit;
+}
+
+$polygon = json_decode($geoRow['coordinates'], true);
+if (!is_array($polygon)) {
+    echo json_encode(['success' => false, 'message' => 'Invalid geofence data.']);
+    exit;
+}
+$randomPoint = randomPointInPolygon($polygon);
+$coordinate = $randomPoint[0] . ',' . $randomPoint[1];
+
 $sql = "INSERT INTO equipment_status_form (
             operator, current_status, location, equipment, status,
             monday_status, tuesday_status, wednesday_status, thursday_status, friday_status, saturday_status, sunday_status,
             downtime, planned_downtime_start, planned_downtime_end, unplanned_downtime_start, unplanned_downtime_end,
+            coordinate,
             created_at
         ) VALUES (
             :operator, :current_status, :location, :equipment, :status,
             :monday, :tuesday, :wednesday, :thursday, :friday, :saturday, :sunday,
             :downtime, :planned_start, :planned_end, :unplanned_start, :unplanned_end,
+            :coordinate,
             NOW()
         )";
 
@@ -83,6 +138,7 @@ try {
         ':planned_end' => $plannedEnd,
         ':unplanned_start' => $unplannedStart,
         ':unplanned_end' => $unplannedEnd,
+        ':coordinate' => $coordinate,
     ]);
 
     echo json_encode(['success' => true]);


### PR DESCRIPTION
## Summary
- derive random coordinates inside selected geofence
- persist generated coordinate with equipment status submission

## Testing
- `php -l submit.php`


------
https://chatgpt.com/codex/tasks/task_e_68a57d707800833188c31b510c9fcd09