### PR TITLE
Enable optional downtime fields and show 24-hour time inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-GB">
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/submit.php
+++ b/submit.php
@@ -70,22 +70,17 @@ foreach ($days as $day) {
 }
 
 $downtime = isset($_POST['downtime']) ? 1 : 0;
-$plannedStart = $_POST['planned_downtime_start'] ?? null;
-$plannedEnd = $_POST['planned_downtime_end'] ?? null;
-$unplannedStart = $_POST['unplanned_downtime_start'] ?? null;
-$unplannedEnd = $_POST['unplanned_downtime_end'] ?? null;
+$plannedStart = ($_POST['planned_downtime_start'] ?? '') ?: null;
+$plannedEnd = ($_POST['planned_downtime_end'] ?? '') ?: null;
+$unplannedStart = ($_POST['unplanned_downtime_start'] ?? '') ?: null;
+$unplannedEnd = ($_POST['unplanned_downtime_end'] ?? '') ?: null;
 
 if ($operator === '' || $currentStatus === '' || $location === '' || $equipment === '' || $status === '') {
     echo json_encode(['success' => false, 'message' => 'Operator, current status, location, equipment and inspection are required.']);
     exit;
 }
 
-if ($downtime) {
-    if ($plannedStart === '' || $plannedEnd === '' || $unplannedStart === '' || $unplannedEnd === '') {
-        echo json_encode(['success' => false, 'message' => 'All downtime fields are required when downtime is enabled.']);
-        exit;
-    }
-}
+// Downtime details are optional even when downtime is marked
 
 // Fetch polygon for selected location and generate random coordinate
 $geoStmt = $pdo->prepare('SELECT coordinates FROM geofences WHERE name = :name LIMIT 1');


### PR DESCRIPTION
## Summary
- Switch page language to `en-GB` so time inputs use a 24‑hour clock.
- Allow planned/unplanned downtime start and end times to be left blank even when downtime is enabled.

## Testing
- `php -l submit.php`

------
https://chatgpt.com/codex/tasks/task_e_68a6af5946d483319ddcb22f6c34c0a3